### PR TITLE
Feat/add gsutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 GitHub Action which allows interacting with [Google Cloud Platform](https://cloud.google.com).
 
 ## Usage
+
 To use gcloud in your workflow use:
 
 ```yaml
@@ -18,13 +19,29 @@ To use gcloud in your workflow use:
 
 Args put command which needs to be executed.
 
+You can also use `gsutil` which is packaged in the Google Cloud SDK.
+
+```yaml
+- uses: actions-hub/gcloud@master
+  env:
+    PROJECT_ID: test
+    APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+    CLI: gsutil
+  with:
+    args: cp your-file.txt gs://your-bucket/
+```
+
 ### Secrets
+
 `APPLICATION_CREDENTIALS` - To authorize in GCP you need to have a [service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey). Required Base64 encoded service account key exported as JSON.
 To encode a JSON file use: `base64 ~/<account_id>.json`
 
 `PROJECT_ID` - must be provided to activate a specific project.
 
+`CLI` - (optional) command line tool you want to use. Defaults to `gcloud`, authorized values: `gcloud`, `gsutil`.
+
 ### Example
+
 ```yaml
 name: gcloud
 on: [push]
@@ -45,4 +62,5 @@ jobs:
 ```
 
 ## Licence
+
 [MIT License](https://github.com/actions-hub/gcloud/blob/master/LICENSE)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,16 +19,12 @@ if [ ! -d "$HOME/.config/gcloud" ]; then
    gcloud config set project "$PROJECT_ID"
 fi
 
-
-authorized_clis=("gcloud" "gsutil")
 echo ::add-path::/google-cloud-sdk/bin/gcloud
 echo ::add-path::/google-cloud-sdk/bin/gsutil
 
 command="gcloud"
-if [ -n "$CLI" ]; then
-   if [[ " ${authorized_clis[@]} " =~ " $CLI " ]]; then
-      command=$CLI
-   fi
+if [ "$CLI" == "gsutil" ]; then
+   command=$CLI
 fi
 
 if [[ ! $# -eq 0 ]] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,18 @@ if [ ! -d "$HOME/.config/gcloud" ]; then
    gcloud config set project "$PROJECT_ID"
 fi
 
+
+authorized_clis=(gcloud gsutil)
 echo ::add-path::/google-cloud-sdk/bin/gcloud
+echo ::add-path::/google-cloud-sdk/bin/gsutil
+
+command="gcloud"
+if [ -n "$CLI" ]; then
+   if [[ " ${authorized_clis[@]} " =~ " $CLI " ]]; then
+      command=$CLI
+   fi
+fi
 
 if [[ ! $# -eq 0 ]] ; then
-    sh -c "gcloud $*"
+    sh -c "$command $*"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ if [ ! -d "$HOME/.config/gcloud" ]; then
 fi
 
 
-authorized_clis=(gcloud gsutil)
+authorized_clis=("gcloud" "gsutil")
 echo ::add-path::/google-cloud-sdk/bin/gcloud
 echo ::add-path::/google-cloud-sdk/bin/gsutil
 


### PR DESCRIPTION
Hi,

Thanks for making this action available to the community, it's really useful.

The Google Cloud SDK installs not only `gcloud`, but also other CLIs such as `gsutil` to manage storage buckets, `bq` for big query, etc. This PR adds the possibility to run `gsutil` commands instead of `gcloud` by specifying an optional `env` parameter called `CLI`. I've updated the README.

Would you be keen to add this? Let me know if there are any changes that you would like.

Cheers,
Thibaut

PS: better squash these nasty commits when you merge ;)