### PR TITLE
Update Config on Every Run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,10 @@ inputs:
     required: true
   project_id:
     description: 'The project id for your project.'
-    required: true
+    required: false # Set to false for backwards capability but should be provided using with.
   application_credentials:
     description: 'The application credentials for accessing your GCP account.'
-    required: true
+    required: false # Set to false for backwards capability but should be provided using with.
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ inputs:
   args:
     description: 'Arguments for the CLI command'
     required: true
+  project_id:
+    description: 'The project id for your project.'
+    required: true
+  application_credentials:
+    description: 'The application credentials for accessing your GCP account.'
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,10 @@ inputs:
     required: true
   project_id:
     description: 'The project id for your project.'
-    required: false # Set to false for backwards capability but should be provided using with.
+    required: false # Set to false for backwards compatible but should be provided using with.
   application_credentials:
     description: 'The application credentials for accessing your GCP account.'
-    required: false # Set to false for backwards capability but should be provided using with.
+    required: false # Set to false for backwards compatible but should be provided using with.
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,8 @@ branding:
   icon: 'cloud'
   color: 'blue'
 inputs:
-  PROJECT_ID:
-    description: 'Project id'
-    required: true
-  APPLICATION_CREDENTIALS:
-    description: 'GCP authorization credentials'
+  args:
+    description: 'Arguments for the CLI command'
     required: true
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ then
   exit 1
 fi
 
-# This allows for backwards capability. The old way is setting the env, but this
+# This allows for backwards compatible. The old way is setting the env, but this
 # handles env not set use input.
 if [ -z $PROJECT_ID ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,20 +3,39 @@
 set -e
 
 
-if [ -z "${APPLICATION_CREDENTIALS-}" ]; then
+if [[ -z "$APPLICATION_CREDENTIALS" ] && [ -z "$INPUT_APPLICATION_CREDENTIALS" ]]
+then
   echo "APPLICATION_CREDENTIALS not found. Exiting...."
   exit 1
-else
-  echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
-  gcloud auth activate-service-account --key-file=/tmp/account.json
 fi
 
-if [ -z "${PROJECT_ID-}" ]; then
+# This allows for backwards capability. The old way is setting the env, but this
+# handles env not set use input.
+if [ -z $APPLICATION_CREDENTIALS ]
+then
+  APPLICATION_CREDENTIALS=$INPUT_APPLICATION_CREDENTIALS
+fi
+
+# Credentials are provided so they will be used.
+echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
+gcloud auth activate-service-account --key-file=/tmp/account.json
+
+# Either the env.PROJECT_ID needs to be set or input.PROJECT_ID.
+if [[ -z "$PROJECT_ID" ] && [ -z "$INPUT_PROJECT_ID" ]]
+then
   echo "PROJECT_ID not found. Exiting...."
   exit 1
-else
-  gcloud config set project "$PROJECT_ID"
 fi
+
+# This allows for backwards capability. The old way is setting the env, but this
+# handles env not set use input.
+if [ -z $PROJECT_ID ]
+then
+  PROJECT_ID=$INPUT_PROJECT_ID
+fi
+
+# Set the project id
+gcloud config set project "$PROJECT_ID"
 
 echo ::add-path::/google-cloud-sdk/bin/gcloud
 echo ::add-path::/google-cloud-sdk/bin/gsutil

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,21 +2,20 @@
 
 set -e
 
-if [ ! -d "$HOME/.config/gcloud" ]; then
-   if [ -z "${APPLICATION_CREDENTIALS-}" ]; then
-      echo "APPLICATION_CREDENTIALS not found. Exiting...."
-      exit 1
-   fi
 
-   if [ -z "${PROJECT_ID-}" ]; then
-      echo "PROJECT_ID not found. Exiting...."
-      exit 1
-   fi
+if [ -z "${APPLICATION_CREDENTIALS-}" ]; then
+  echo "APPLICATION_CREDENTIALS not found. Exiting...."
+  exit 1
+else
+  echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
+  gcloud auth activate-service-account --key-file=/tmp/account.json
+fi
 
-   echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
-
-   gcloud auth activate-service-account --key-file=/tmp/account.json
-   gcloud config set project "$PROJECT_ID"
+if [ -z "${PROJECT_ID-}" ]; then
+  echo "PROJECT_ID not found. Exiting...."
+  exit 1
+else
+  gcloud config set project "$PROJECT_ID"
 fi
 
 echo ::add-path::/google-cloud-sdk/bin/gcloud


### PR DESCRIPTION
## Part 1

Updated the `action.yml` to represent the correct inputs.

```
- uses: actions-hub/gcloud@master
  env:
    PROJECT_ID: test
    APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
  with:
    args: info
```

The `with` is looking for `inputs` `args`. `PROJECT_ID` and `APPLICATION_CREDENTIALS` are environment variables. This will eliminate this warning:

```
##[warning]Unexpected input 'args', valid inputs are ['PROJECT_ID', 'APPLICATION_CREDENTIALS']
```


## Part 2

Updated the arguments to not check for `"$HOME/.config/gcloud"` anymore. We were running into an issue where if we want to run two deployments on two different projects using one workflow, project 2 would use project 1's configuration files since `.config/gcloud` already existed. It didn't matter we were passing in a new `PROJECT_ID`.

This can be reproduced with:

```
name: Demo
on:
  push:
    branches:
      - master
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    # Insert general steps that dont need to be run twice.
    - name: Deploy Project 1
      uses: actions-hub/gcloud@master
      env:
        PROJECT_ID: <ProjectID1>
        APPLICATION_CREDENTIALS: ${{secrets.GCLOUD }}
      with:
        args: "app deploy ProjectID1.yaml"
    - name: Deploy Project 2
      uses: actions-hub/gcloud@master
      env:
        PROJECT_ID: <ProjectID2>
        APPLICATION_CREDENTIALS: ${{secrets.GCLOUD }}
      with:
        args: "app deploy ProjectID2.yaml"
```

During the project 2 step, it would use `ProjectID2.yaml` but `PROJECT_ID` was still `<ProjectID1>`.
