### PR TITLE
Work without encoding the secret with base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ You can also use `gsutil` from Google Cloud SDK package.
 
 ### Secrets
 
-`APPLICATION_CREDENTIALS` - To authorize in GCP you need to have a [service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey). Required Base64 encoded service account key exported as JSON.
-To encode a JSON file use: `base64 ~/<account_id>.json`
+`APPLICATION_CREDENTIALS` - To authorize in GCP you need to have a [service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey). 
+You can also pass a base64 encoded string. To encode a JSON file use: `base64 ~/<account_id>.json`. 
 
 `PROJECT_ID` - must be provided to activate a specific project.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,14 @@ if [ ! -d "$HOME/.config/gcloud" ]; then
         exit 1
     fi
 
-    echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
+    # Check if $APPLICATION_CREDENTIALS is a valid base64 encoded string or not
+    if [ "$APPLICATION_CREDENTIALS" = "$(echo "$APPLICATION_CREDENTIALS" | base64 -d | base64  | tr -d \\n)" ]; then
+      echo "APPLICATION_CREDENTIALS is Base64 Encoded"
+      echo "$APPLICATION_CREDENTIALS" | base64 -d > /tmp/account.json
+    else
+      echo "APPLICATION_CREDENTIALS is not Base64 Encoded"
+      echo "$APPLICATION_CREDENTIALS" > /tmp/account.json
+    fi
 
     gcloud auth activate-service-account --key-file=/tmp/account.json
     gcloud config set project "$PROJECT_ID"


### PR DESCRIPTION
This PR maintains backwards-compatibility and removes the need of having a base64 encoded Secret

