### PR TITLE
Prebuild Docker image to improve build time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: Build Docker image
+
+on: [push, pull_request]  # TMP
+
+env:
+  IMAGE_NAME: actions-hub-gcloud
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log into registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: Build Docker image
 
-on: [push, pull_request]  # TMP
+on:
+  release:
+    types: [published]
 
 env:
   IMAGE_NAME: actions-hub-gcloud
@@ -18,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME:latest --tag $IMAGE_NAME:$GITHUB_REF --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log into registry
         # This is where you will update the PAT to GITHUB_TOKEN

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME:latest --tag $IMAGE_NAME:${{ github.event.release.tag_name }} --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log into registry
         # This is where you will update the PAT to GITHUB_TOKEN

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME:latest --tag $IMAGE_NAME:$GITHUB_REF --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME:latest --tag $IMAGE_NAME:${{ github.event.release.tag_name }} --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log into registry
         # This is where you will update the PAT to GITHUB_TOKEN

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Replace image in action.yml by local Dockerfile
+        run: |
+          FROM_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:.*"
+          TO_LINE="image: Dockerfile"
+          sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/action.yml
+
       - uses: ./
         env:
           PROJECT_ID: ${{secrets.GCP_PROJECT_ID}}
@@ -20,6 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Replace image in action.yml by local Dockerfile
+        run: |
+          FROM_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:.*"
+          TO_LINE="image: Dockerfile"
+          sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/action.yml
+
       - uses: ./
         env:
           PROJECT_ID: ${{secrets.GCP_PROJECT_ID}}
@@ -31,6 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: Replace image in action.yml by local Dockerfile
+        run: |
+          FROM_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:.*"
+          TO_LINE="image: Dockerfile"
+          sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/action.yml
 
       - uses: ./
         env:
@@ -45,6 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: Replace image in action.yml by local Dockerfile
+        run: |
+          FROM_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:.*"
+          TO_LINE="image: Dockerfile"
+          sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/action.yml
 
       - uses: ./
         env:

--- a/.github/workflows/upgrader.yaml
+++ b/.github/workflows/upgrader.yaml
@@ -66,7 +66,7 @@ jobs:
             echo "Docker hub returns $status_code"
           fi
 
-      - name: Modify Dockerfile
+      - name: Modify Dockerfile and action.yml
         id: modify
         if: success() && steps.check.outputs.newest == 'yes' && steps.test.outputs.exist == 'yes'
         run: |
@@ -79,6 +79,10 @@ jobs:
           FROM_LINE="FROM google\/cloud-sdk:$LATEST_VERSION-alpine"
           TO_LINE="FROM google\/cloud-sdk:$SDK_VERSION-alpine"
           sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/Dockerfile
+
+          FROM_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:$LATEST_VERSION"
+          TO_LINE="image: ghcr.io\/${{ github.repository_owner }}\/actions-hub-gcloud:$SDK_VERSION"
+          sed -i "s/${FROM_LINE}/${TO_LINE}/" $GITHUB_WORKSPACE/action.yml
 
           git add $GITHUB_WORKSPACE/Dockerfile
           git commit -m "updated gcloud-sdk to $SDK_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -14,4 +14,4 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: ghcr.io/frankie567/actions-hub-gcloud:343.0.0

--- a/action.yml
+++ b/action.yml
@@ -14,4 +14,4 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: ghcr.io/frankie567/actions-hub-gcloud:343.0.0
+  image: ghcr.io/actions-hub/actions-hub-gcloud:343.0.0


### PR DESCRIPTION
Follow-up of the discussion in #29.

Summary of the changes:

* Adds a new workflow `build.yaml` that builds and pushes a Docker image to the GitHub registry when a **release is published**
* `action.yml` now uses the prebuilt image instead of the Dockerfile
* In the workflow `upgrader.yaml`, we take care of replacing the tag in `action.yml` so it uses the newly tagged image
* In `test.yml`, before running the test, we manually replace the image path by `Dockerfile`
    * It's needed to be sure we are testing the latest changes. Otherwise, we would have issues because it could try to test an image that hasn't been built yet.

To make it work on you repository, you'll need to enable the improved Container registry on your GitHub organization: https://docs.github.com/en/packages/working-with-a-github-packages-registry/enabling-improved-container-support-with-the-container-registry#enabling-the-container-registry-for-your-organization-account

I hope it'll be helpful! Feel free to suggest improvements 😄