### PR TITLE
Add support for 'beta' commands.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,10 @@ if [ "$CLI" = "kubectl" ] || [ "$INPUT_CLI" = "kubectl" ]; then
     command="kubectl"
 fi
 
+if [ "$command" = "gcloud" ] && [ "$1" = "beta" ]; then
+    gcloud components install beta
+fi
+
 if [ ! $# -eq 0 ]; then
     sh -c "$command $*"
 fi


### PR DESCRIPTION
Manually install the `beta` component if specified.

`gcloud` claims that `--quiet` will automatically install the `beta` component. However, that doesn't seem to be functional. This change will do the install during the action.